### PR TITLE
Add comprehensive project documentation hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+.next
+.out
+.vercel
+.env
+.env.local
+.env.*
+dist
+coverage
+.vscode
+.idea
+.DS_Store
+
+# pnpm store
+.pnpm-store

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# SprayFoam TV Documentation Hub
+
+Welcome to the knowledge base for the SprayFoam TV web application. This `/docs` directory centralises every resource an AI or human contributor needs to understand the current state of the project, its technical foundations, and the roadmap ahead.
+
+- **Start with [`project-overview.md`](./project-overview.md)** for the mission, audience, and feature summary.
+- **Review [`architecture.md`](./architecture.md)** to understand the file structure, technology stack, and component relationships.
+- **Follow [`development-guide.md`](./development-guide.md)** for environment setup, common commands, and collaboration conventions.
+- **Consult [`ui-component-catalog.md`](./ui-component-catalog.md)** for implementation details of each reusable component.
+- **Track plans in [`roadmap.md`](./roadmap.md)** and current execution status in [`progress-tracker.md`](./progress-tracker.md).
+
+## Keeping documentation current
+
+- Update the relevant document whenever you change or add a feature.
+- Log progress in [`progress-tracker.md`](./progress-tracker.md) at the end of each significant change. This file contains a changelog-friendly table plus tips for future updates.
+- When planning work, synchronise tasks between [`roadmap.md`](./roadmap.md) and the tracker so that other contributors immediately know priorities and remaining effort.
+
+Maintaining this folder ensures that any future AI agent can quickly pick up context, plan the next steps, and keep the project moving forward.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,57 @@
+# Architecture & Codebase Tour
+
+## Technology Stack
+- **Framework:** Next.js 15 (App Router)
+- **Language:** TypeScript with React 19
+- **Styling:** Tailwind CSS (via `app/globals.css`) with utility-first patterns and custom font variables (Geist Sans & Mono)
+- **Component library primitives:** Local UI system derived from shadcn/ui stored in `components/ui`
+- **Icons:** `lucide-react`
+- **Analytics:** `@vercel/analytics`
+
+## Directory Layout
+```
+.
+├── app/
+│   ├── globals.css         // Tailwind layer definitions and global tokens
+│   ├── layout.tsx          // Root layout (fonts, Suspense boundary, Analytics)
+│   └── page.tsx            // Homepage composition
+├── components/
+│   ├── header.tsx          // Sticky global navigation
+│   ├── live-hero.tsx       // Live stream hero banner
+│   ├── schedule-preview.tsx// Daily schedule cards
+│   ├── content-carousel.tsx// Generic carousel for multiple content types
+│   ├── cta-section.tsx     // Dual call-to-action cards
+│   ├── footer.tsx          // Footer navigation and attribution
+│   ├── theme-provider.tsx  // (Currently unused) theming helper for dark/light support
+│   └── ui/                 // Shared UI primitives (Button, Card, Badge, etc.)
+├── public/                 // Static assets referenced by components
+├── styles/                 // Tailwind configuration extensions
+└── docs/                   // Living documentation hub (this folder)
+```
+
+## Component Composition
+`app/page.tsx` imports each major section component. Data for carousels is defined inline in the page and passed via props, while each section controls its own markup and styling.
+
+### State & Interactivity
+- `LiveHero` manages a local `isPlaying` state that toggles playback iconography.
+- `ContentCarousel` maintains a `startIndex` state to paginate visible cards; navigation buttons mutate this state.
+- All other sections render static content and rely on CSS for hover/active affordances.
+
+### Styling Conventions
+- Utility classes express layout, spacing, and typographic hierarchy. Tailwind's design tokens (e.g., `bg-card`, `text-muted-foreground`) map to the theme defined in `globals.css`.
+- Cards use `group`/`group-hover` to animate images on hover, emphasising featured content.
+- Responsiveness is driven by Tailwind breakpoints (`md`, `lg`) to adjust grid layouts and navigation visibility.
+
+### Fonts & Layout
+`app/layout.tsx` wires Geist Sans and Geist Mono via the `next/font` API and exposes them as CSS variables applied to the `<body>`. A top-level `<Suspense>` boundary enables future streaming data fetching with graceful fallbacks.
+
+## External Integrations & Future Hooks
+- The header/footer link to routes that do not yet exist; creating corresponding pages will be a first step when expanding content.
+- `theme-provider.tsx` is scaffolded but unused. Enabling it would add dark-mode support across components.
+- Static arrays in `app/page.tsx` should ultimately be replaced with data fetching functions (e.g., `generateStaticParams`, server actions, CMS clients).
+
+## Testing & Quality
+No automated tests are configured yet. When introducing tests consider:
+- Component-level testing with React Testing Library or Storybook for visual regression.
+- Type safety enforced via TypeScript; keep strict mode enabled in `tsconfig.json` when possible.
+- Linting available via `pnpm lint` (Next.js built-in ESLint config).

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,0 +1,43 @@
+# Development Guide
+
+This guide outlines how to set up, run, and contribute to the SprayFoam TV project.
+
+## Prerequisites
+- Node.js 20.x (align with Next.js 15 requirements)
+- pnpm (preferred package manager)
+- Git
+
+## Initial Setup
+```bash
+pnpm install
+```
+
+## Common Scripts
+| Command | Description |
+| --- | --- |
+| `pnpm dev` | Start the development server on `http://localhost:3000`. |
+| `pnpm build` | Create a production build. |
+| `pnpm start` | Run the production build locally. |
+| `pnpm lint` | Execute the Next.js ESLint rules. |
+
+## Environment Variables
+No environment variables are currently required. As integrations are introduced (e.g., CMS, auth, analytics keys), document them here with sample `.env.local` entries.
+
+## Styling Workflow
+- Tailwind CSS drives all styling. Use utility classes and avoid inline styles.
+- Shared primitives (Button, Card, Badge, etc.) live in `components/ui`. Prefer these before creating new bespoke elements.
+- Fonts are configured in `app/layout.tsx`; add new fonts via the `next/font` API to ensure optimal loading.
+
+## Asset Management
+- Place static images in `public/` and reference them with root-relative paths (e.g., `/image.png`).
+- Optimise image dimensions to match usage. Consider `next/image` when integrating real assets.
+
+## Collaboration Conventions
+- Reference [`roadmap.md`](./roadmap.md) for priority initiatives before picking up new work.
+- Log updates in [`progress-tracker.md`](./progress-tracker.md) after each PR merges.
+- Keep commits scoped and descriptive (e.g., `feat: add schedule API` or `docs: update roadmap`).
+- When adding new sections, update [`project-overview.md`](./project-overview.md) and [`ui-component-catalog.md`](./ui-component-catalog.md) accordingly.
+
+## Testing Strategy (Future)
+- Introduce unit/component tests alongside new features.
+- Add a CI pipeline to run `pnpm lint` and future test suites before merge.

--- a/docs/progress-tracker.md
+++ b/docs/progress-tracker.md
@@ -1,0 +1,21 @@
+# Progress Tracker
+
+Use this tracker to capture the current status of major workstreams. Update the **Status** column (`Not Started`, `In Progress`, `Blocked`, `Complete`) and adjust the **Owner/Notes** field with actionable context after each meaningful change.
+
+| Area | Status | Last Updated | Owner/Notes |
+| --- | --- | --- | --- |
+| Documentation hub | Complete | 2025-02-14 | Initial `/docs` suite created (overview, architecture, guide, components, roadmap, tracker). |
+| Routing expansion | Not Started | 2025-02-14 | Header/footer links still point to non-existent routes. Create stub pages next. |
+| Data sourcing | Not Started | 2025-02-14 | Homepage uses static arrays in `app/page.tsx`; plan CMS/API integration. |
+| Streaming integration | Not Started | 2025-02-14 | `LiveHero` uses static imagery; awaiting player selection (Mux/Vimeo/etc.). |
+| Responsive navigation | Not Started | 2025-02-14 | Mobile menu button is non-functional; implement drawer with Radix UI. |
+| Theming | Not Started | 2025-02-14 | `theme-provider.tsx` unused; add dark mode toggle and apply tokens. |
+| Community workflows | Not Started | 2025-02-14 | Submit video / contractor flows not implemented. |
+
+## How to Update
+1. Change the **Status** and **Last Updated** date when progress occurs.
+2. Summarise decisions, blockers, or follow-up tasks in **Owner/Notes**.
+3. For larger milestones, append a short changelog entry below.
+
+## Changelog
+- **2025-02-14:** Seeded tracker with baseline statuses and created documentation hub.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,0 +1,38 @@
+# Project Overview
+
+## Vision
+SprayFoam TV is a streaming hub designed for spray foam insulation professionals. The site highlights a live broadcast, curated schedule highlights, on-demand episode carousels, and calls-to-action that convert viewers into contributors, contractors, or sponsors.
+
+## Target Audience
+- **Spray foam contractors** seeking continuous education and industry updates.
+- **Manufacturers and vendors** looking for sponsorship and advertising opportunities.
+- **Homeowners or facilities managers** interested in finding vetted spray foam specialists.
+
+## Core Value Proposition
+1. **Always-on expertise** – a hero section emulating a live stream with contextual controls.
+2. **At-a-glance programming** – a daily schedule preview highlighting currently live and upcoming shows.
+3. **Curated libraries** – carousels for recent episodes, popular shows, and upcoming events.
+4. **Action-oriented CTAs** – dedicated cards to submit content or find contractors.
+5. **Trust-building footer** – navigation shortcuts and company details that reinforce credibility.
+
+## Current Feature Set
+| Area | Description | Files |
+| --- | --- | --- |
+| Global layout | App Router layout with Geist font pairing and analytics instrumentation. | `app/layout.tsx`
+| Homepage composition | Stitches together hero, schedule, carousels, CTA, and footer. | `app/page.tsx`
+| Header | Sticky navigation with responsive menu controls. | `components/header.tsx`
+| Live hero | Live stream hero banner with playback controls and CTA buttons. | `components/live-hero.tsx`
+| Schedule preview | Four-card summary of the daily programming slate. | `components/schedule-preview.tsx`
+| Content carousel | Generic carousel powering episodes, shows, and events sections. | `components/content-carousel.tsx`
+| CTA section | Dual call-to-action cards for video submission and contractor search. | `components/cta-section.tsx`
+| Footer | Multi-column resource footer with dynamic copyright. | `components/footer.tsx`
+
+## Content Model Snapshot
+Current data is mocked directly in `app/page.tsx` as static arrays (`recentEpisodes`, `popularShows`, and `upcomingEvents`). These lists populate the `ContentCarousel` component. Future integrations should plan to replace these with CMS or API-driven data sources.
+
+## Future Opportunities
+- Expand routing to match header/footer navigation targets (Schedule, Shows, Events, etc.).
+- Integrate a real streaming player in `LiveHero` and connect the controls to playback state.
+- Externalise schedule and carousel data to a CMS or serverless API.
+- Layer in authentication and user preferences (e.g., watchlists, reminders).
+- Introduce sponsorship management tools and analytics dashboards.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,32 @@
+# Roadmap
+
+The roadmap aligns near-term engineering tasks with longer-term strategic goals. Update this document as priorities shift.
+
+## Milestone 0 – Foundation Hardening (Current)
+- [ ] Stand up actual schedule, shows, events pages matching header/footer links.
+- [ ] Replace mock carousel data with a temporary JSON data source or CMS integration.
+- [ ] Implement responsive mobile navigation (hamburger menu -> drawer).
+- [ ] Add dark mode support via `theme-provider.tsx` and Tailwind tokens.
+
+## Milestone 1 – Streaming Experience
+- [ ] Integrate a real streaming player in `LiveHero` (e.g., Mux, Vimeo, or HLS).
+- [ ] Surface metadata overlays (now playing, hosts, viewer count, sponsor badge).
+- [ ] Add watch reminder CTA with email collection or calendar integration.
+
+## Milestone 2 – Community & Monetisation
+- [ ] Build submission form workflow for contributors (upload or link media).
+- [ ] Launch contractor directory with filtering, regional search, and lead capture.
+- [ ] Publish sponsor kit landing page with pricing tiers and contact form.
+
+## Milestone 3 – Personalisation & Accounts
+- [ ] Introduce authentication to support saved shows and watchlists.
+- [ ] Implement personalised recommendations on the homepage.
+- [ ] Add analytics dashboards for sponsors/partners to review engagement.
+
+## Backlog & Ideas
+- Interactive schedule timeline with timezone awareness.
+- Episode detail pages with transcripts, resource links, and related content.
+- CMS-driven editorial blog for industry news.
+- Mobile app parity (React Native or Expo) leveraging shared component logic.
+
+Whenever an item is started or completed, reflect that status here and mirror it in [`progress-tracker.md`](./progress-tracker.md).

--- a/docs/ui-component-catalog.md
+++ b/docs/ui-component-catalog.md
@@ -1,0 +1,41 @@
+# UI Component Catalog
+
+This catalog documents each reusable component shipped with the homepage foundation. Update this file whenever components change or new ones are added.
+
+## Global Sections
+### `Header`
+- **Purpose:** Persistent top navigation with brand identity, route links, and primary CTAs.
+- **Key props/state:** None; renders static links. Responsive behaviour hides/show buttons using Tailwind breakpoints.
+- **Future enhancements:** Implement mobile navigation drawer and wire CTA buttons to actual forms.
+
+### `LiveHero`
+- **Purpose:** Mimics a live streaming experience with hero imagery, program details, and playback controls.
+- **Key props/state:** Internal `isPlaying` boolean toggles play/pause icon. Buttons currently placeholders for future player integration.
+- **Future enhancements:** Replace static background with an embedded player (`next/dynamic` + HLS), connect controls to playback, display metadata (host, viewer count).
+
+### `SchedulePreview`
+- **Purpose:** Highlights today's programming in a responsive grid.
+- **Key props/state:** Local `schedule` array (hardcoded) with `time`, `title`, and `status`. Status drives styling for the live entry.
+- **Future enhancements:** Accept schedule data via props, link each card to detailed show pages, show timezone conversions.
+
+### `ContentCarousel`
+- **Purpose:** Generic carousel for episodes, shows, and events.
+- **Props:**
+  - `title: string` – section heading.
+  - `items: CarouselItem[]` – array containing fields such as `title`, `thumbnail`, `duration`, `episodes`, `date`, and `location`.
+- **State:** `startIndex` integer to control the current window of items (4 visible at a time).
+- **Behaviours:** Prev/next buttons clamp the index to `0` and `items.length - 4`. Cards display contextual metadata (duration, episode count, date/location) when provided.
+- **Future enhancements:** Add keyboard navigation, autoplay, drag/scroll gestures, and responsive item counts.
+
+### `CTASection`
+- **Purpose:** Drive user conversion with two prominent cards (Submit Video, Find a Contractor).
+- **Key props/state:** None; CTA destinations are static routes.
+- **Future enhancements:** Track clicks, personalise CTAs based on user type, and integrate form modals.
+
+### `Footer`
+- **Purpose:** Provide secondary navigation, community links, and company info.
+- **Key props/state:** None; includes dynamic copyright year.
+- **Future enhancements:** Add newsletter signup, social links, localisation-aware content.
+
+## Shared UI Primitives (`components/ui`)
+While not exhaustively documented here, the `components/ui` directory contains shadcn-derived primitives (Button, Card, Badge, etc.). When customising or adding primitives, update this section with API notes and usage examples to prevent duplication.


### PR DESCRIPTION
## Summary
- add a /docs knowledge base covering project overview, architecture, and development practices
- document the UI component catalog plus roadmap and progress tracker for future planning
- introduce a repository .gitignore to exclude build artifacts and node_modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1c8370ae08325b24a304215fcaa84