### PR TITLE
Handle AI video jobs asynchronously to avoid timeouts

### DIFF
--- a/app/api/video-jobs/route.ts
+++ b/app/api/video-jobs/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
       result: job.result,
       error: job.error,
       createdAt: job.createdAt,
-      updatedAt: new Date() // Since we don't track this in temp storage
+      updatedAt: job.updatedAt,
     })
   } catch (error) {
     console.error('Error getting video job:', error)


### PR DESCRIPTION
## Summary
- queue AI video generation requests immediately and return a job identifier so the client can poll instead of timing out
- move the Hugging Face call into a background worker that targets the fal-ai provider and converts the result into a data URL
- expose real updatedAt metadata in the job status endpoint so polling reflects the latest state

## Testing
- pnpm lint *(fails: command prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e920e44a5883259cf0db0c9eec74d2