### PR TITLE
Handle JSON video payload responses

### DIFF
--- a/app/api/generate-video/route.ts
+++ b/app/api/generate-video/route.ts
@@ -152,10 +152,55 @@ async function processVideoGenerationAsync(jobId: string, prompt: string, imageA
 
     updateJob(jobId, { progress: 80 })
 
-    // Convert video to base64 for inline playback on the client
+    // Convert video for inline playback. Some providers (like fal.ai) first
+    // return a JSON payload containing a temporary download URL while others
+    // stream the binary video directly. We handle both cases so the client
+    // always receives a usable source.
     const videoArrayBuffer = await videoBlob.arrayBuffer()
+    const detectedMimeType = (videoBlob.type || '').toLowerCase()
+
+    if (videoArrayBuffer.byteLength === 0) {
+      throw new Error('Received empty video data from provider')
+    }
+
+    const isJsonPayload = detectedMimeType.includes('application/json') || detectedMimeType.includes('text/plain')
+
+    if (isJsonPayload) {
+      const payloadText = new TextDecoder().decode(videoArrayBuffer)
+
+      try {
+        const payload = JSON.parse(payloadText)
+        const candidateUrls: unknown[] = [
+          payload?.video?.url,
+          payload?.data?.video?.url,
+          payload?.output?.video?.url,
+          payload?.result?.video?.url,
+          Array.isArray(payload?.results) ? payload.results[0]?.video?.url : undefined,
+        ]
+
+        const resolvedUrl = candidateUrls.find((value): value is string => typeof value === 'string' && value.startsWith('http'))
+
+        if (resolvedUrl) {
+          updateJob(jobId, {
+            status: 'completed',
+            progress: 100,
+            result: resolvedUrl,
+            error: undefined,
+          })
+          console.log(`Video generation completed for job ${jobId} (resolved remote URL)`) // eslint-disable-line no-console
+          return
+        }
+
+        console.error(`Video provider returned unexpected JSON payload for job ${jobId}:`, payload)
+        throw new Error('Video provider returned an unexpected response format')
+      } catch (parseError) {
+        console.error(`Failed to parse JSON video payload for job ${jobId}:`, parseError)
+        throw new Error('Unable to parse video response from provider')
+      }
+    }
+
     const base64Video = Buffer.from(videoArrayBuffer).toString('base64')
-    const videoMimeType = videoBlob.type || 'video/mp4'
+    const videoMimeType = detectedMimeType || 'video/mp4'
     const videoDataUrl = `data:${videoMimeType};base64,${base64Video}`
 
     updateJob(jobId, {


### PR DESCRIPTION
## Summary
- add provider response handling so JSON payloads with remote video URLs resolve before updating job status
- retain base64 encoding for binary responses while guarding against empty payloads

## Testing
- pnpm lint *(fails: command prompts for interactive configuration in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e92470c5ac83259a56910c1e25091b